### PR TITLE
Fix rendering error in German translation

### DIFF
--- a/src/SBLib/source/CFont.cpp
+++ b/src/SBLib/source/CFont.cpp
@@ -310,7 +310,7 @@ SLONG SB_CFont::GetWordLength(const char* str, SLONG offset)
 SLONG SB_CFont::GetWidth(char ch)
 {
     if ((this->Header.Flags & 1) == 1)
-        return *(this->VarWidth + ch);
+        return this->VarWidth[(unsigned char)ch];
     else
         return this->Header.Width;
 }
@@ -349,7 +349,7 @@ bool SB_CFont::DrawChar(char ch, bool)
         {
             SDL_Rect srcRect;
             srcRect.x = 0;
-            srcRect.y = (*(this->VarHeight + ch) - this->Header.LoChar) * this->Header.Height;
+            srcRect.y = ((this->VarHeight[(unsigned char)ch]) - this->Header.LoChar) * this->Header.Height;
             srcRect.w = this->Header.Width;
             srcRect.h = this->Header.Height;
             if (!this->Hidden)


### PR DESCRIPTION
Fixes  #18

Before:
![AT_2022-03-13_16-36-52](https://user-images.githubusercontent.com/3768165/158067338-2a4f2ede-496f-47b6-a3d5-f44040fccb23.png)
After:
![AT_2022-03-13_16-34-50](https://user-images.githubusercontent.com/3768165/158067315-d85918d8-5fdc-4260-b0f9-2a40ab2eea9d.png)

The german `ö` is char `0xF6` which messes up big time.
In general the char width/height data is 0x100 in size, but its only accessed with signed chars with go up to 127 so you could never reach the top half of that data

